### PR TITLE
Fix broken link in README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,7 @@
 ![WeTTy](./terminal.png?raw=true)
 
 - [Running as daemon](./service.md)
-- [SSL Support](./ssl.md)
+- [HTTPS Support](./https.md)
   - [Using NGINX](./nginx.md)
   - [Using Apache](./apache.md)
 - [Automatic Login](./auto-login.md)


### PR DESCRIPTION
Changed [SSL Support](./ssl.md) to [HTTPS Support](./https.md) to fix a broken relative link as the document had been renamed.